### PR TITLE
Inline and decode game scripts option for one-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,18 @@ There are some limitations:
 - Modules are not supported (Basis and Ammo)
 - Texture compression formats are not supported
 
-An experimental feature is available to patch the engine to not use XHR requests when loading assets. This may be required for some platforms where this is not permitted. As this is a patch, there may be edge cases where some asset types may not work. If you find any any, please report them in the issues.
+### Experimental features
 
-The option can be foind in `config.json` under `one_page`. Set `patch_xhr_out` to true.
+#### Remove XHR requests
+Adds an engine patch to remove any XHR requests and decodes the base64 URLs directly. This may be required for some platforms where this is not permitted. As this is a patch, there may be edge cases where some asset types may not work. If you find any any, please report them in the issues.
+
+The option can be found in `config.json` under `one_page`. Set `patch_xhr_out` to true.
+
+#### Inline game scripts
+Adds an engine patch to decode base64 URLS for JS scripts when the engine adds them to the page document. This may be required for some platforms that block base64 encoded JS URLs. As this is a patch, there may be edge cases where some asset types may not work. If you find any any, please report them in the issues.
+
+The option can be found in `config.json` under `one_page`. Set `inline_game_scripts` to true.
+
 
 ### Usage
 1. `npm run one-page`

--- a/config.template.json
+++ b/config.template.json
@@ -26,6 +26,7 @@
         ]
     },
     "one_page": {
-        "patch_xhr_out": false
+        "patch_xhr_out": false,
+        "inline_game_scripts": false
     }
 }

--- a/engine-patches/one-page-inline-game-scripts.js
+++ b/engine-patches/one-page-inline-game-scripts.js
@@ -1,0 +1,20 @@
+(function () {
+    pc.ScriptHandler.prototype._loadScript = function (url, callback) {
+        var head = document.head;
+        var element = document.createElement('script');
+        this._cache[url] = element;
+
+        // use async=false to force scripts to execute in order
+        element.async = false;
+
+        // Decode the url from base64 to text
+        var index = url.indexOf(',');
+        var base64 = url.slice(index + 1);
+        var data = window.atob(base64);
+
+        element.innerText = data;
+        head.appendChild(element);
+
+        callback(null, url, element);
+    };
+})();

--- a/one-page.js
+++ b/one-page.js
@@ -16,24 +16,34 @@ function inlineAssets(projectPath) {
             var indexLocation = path.resolve(projectPath, "index.html");
             var indexContents = fs.readFileSync(indexLocation, 'utf-8');
 
-            // XHR request patch. We may need to not use XHR due to restrictions on the hosting service
-            // such as Facebook playable ads. If that's the case, we will add a patch to override http.get
-            // and decode the base64 URL ourselves
-            // Copy the patch to the project directory and add the script to index.html
+            var addPatchFile = function (filename) {
+                var patchLocation = path.resolve(projectPath, filename);
+                fs.copyFileSync('engine-patches/' + filename, patchLocation, (err) => {
+                    if (err) {
+                        throw err
+                    }
+                });
+                indexContents = indexContents.replace(
+                    '<script src="playcanvas-stable.min.js"></script>',
+                    '<script src="playcanvas-stable.min.js"></script>\n    <script src="' + filename + '"></script>'
+                );
+            };
+
             (function () {
+                // XHR request patch. We may need to not use XHR due to restrictions on the hosting service
+                // such as Facebook playable ads. If that's the case, we will add a patch to override http.get
+                // and decode the base64 URL ourselves
+                // Copy the patch to the project directory and add the script to index.html
                 if (config.one_page.patch_xhr_out) {
                     console.log("↪️ Adding no XHR engine patch");
-                    var patchFileName = 'one-page-no-xhr-request.js';
-                    var xhrPatchLocation = path.resolve(projectPath, patchFileName);
-                    fs.copyFile('engine-patches/' + patchFileName, xhrPatchLocation, (err) => {
-                        if (err) {
-                            throw err
-                        }
-                    });
-                    indexContents = indexContents.replace(
-                        '<script src="playcanvas-stable.min.js"></script>',
-                        '<script src="playcanvas-stable.min.js"></script>\n    <script src="' + patchFileName + '"></script>'
-                    );
+                    addPatchFile('one-page-no-xhr-request.js');
+                }
+
+                // Inline game scripts patch. Some platforms block base64 JS code so this overrides the addition
+                // of game scripts to the document
+                if (config.one_page.inline_game_scripts) {
+                    console.log("↪️ Adding inline game script engine patch");
+                    addPatchFile('one-page-inline-game-scripts.js');
                 }
             })();
 

--- a/shared.js
+++ b/shared.js
@@ -18,6 +18,7 @@ function readConfig() {
 
     config.one_page = config.one_page || {};
     config.one_page.patch_xhr_out = config.one_page.patch_xhr_out || false;
+    config.one_page.inline_game_scripts = config.one_page.inline_game_scripts || false;
 
     return config;
 }

--- a/shared.js
+++ b/shared.js
@@ -9,7 +9,16 @@ function readConfig() {
     const env = dotenv.config().parsed;
     const configStr = fs.readFileSync('config.json', 'utf-8');
     const config = JSON.parse(configStr);
-    config.authToken = env['AUTH_TOKEN']
+    config.authToken = env['AUTH_TOKEN'];
+
+    // Add defaults if they don't exist
+    config.csp = config.csp || {};
+    config.csp['style-src'] = config.csp['style-src'] || [];
+    config.csp['connect-src'] = config.csp['connect-src'] || [];
+
+    config.one_page = config.one_page || {};
+    config.one_page.patch_xhr_out = config.one_page.patch_xhr_out || false;
+
     return config;
 }
 


### PR DESCRIPTION
Needed for Facebook Playable ads

Without this option, game scripts elements are added to the document with the src as a base64 URL which facebook blocks


https://user-images.githubusercontent.com/16639049/108848753-491e2f00-75d9-11eb-8979-0ee87488a808.mp4

