### PR TITLE
Fixed copyFileSync for Node 14+

### DIFF
--- a/one-page.js
+++ b/one-page.js
@@ -22,11 +22,7 @@ function inlineAssets(projectPath) {
 
             var addPatchFile = function (filename) {
                 var patchLocation = path.resolve(projectPath, filename);
-                fs.copyFileSync('engine-patches/' + filename, patchLocation, (err) => {
-                    if (err) {
-                        throw err
-                    }
-                });
+                fs.copyFileSync('engine-patches/' + filename, patchLocation, fs.constants.COPYFILE_FICLONE);
                 indexContents = indexContents.replace(
                     '<script src="playcanvas-stable.min.js"></script>',
                     '<script src="playcanvas-stable.min.js"></script>\n    <script src="' + filename + '"></script>'
@@ -290,18 +286,10 @@ async function packageFiles (projectPath) {
 
                 // Copy files to a new dir
                 for (const filename of EXTERN_FILES) {
-                    fs.copyFileSync(path.resolve(projectPath, filename), path.resolve(packagePath, filename), (err) => {
-                        if (err) {
-                            throw err
-                        }
-                    });
+                    fs.copyFileSync(path.resolve(projectPath, filename), path.resolve(packagePath, filename), fs.constants.COPYFILE_FICLONE);
                 }
 
-                fs.copyFileSync(indexLocation, path.resolve(packagePath, 'index.html'), (err) => {
-                    if (err) {
-                        throw err
-                    }
-                });
+                fs.copyFileSync(indexLocation, path.resolve(packagePath, 'index.html'), fs.constants.COPYFILE_FICLONE);
 
                 var zipOutputPath = path.resolve(__dirname, 'temp/out/' + config.playcanvas.name + '.zip');
                 await shared.zipProject(packagePath, zipOutputPath);
@@ -315,11 +303,7 @@ async function packageFiles (projectPath) {
                     });
                 }
 
-                fs.copyFileSync(indexLocation, indexOutputPath, (err) => {
-                    if (err) {
-                        throw err
-                    }
-                });
+                fs.copyFileSync(indexLocation, indexOutputPath, fs.constants.COPYFILE_FICLONE);
 
                 resolve(indexOutputPath);
             }

--- a/one-page.js
+++ b/one-page.js
@@ -22,7 +22,7 @@ function inlineAssets(projectPath) {
 
             var addPatchFile = function (filename) {
                 var patchLocation = path.resolve(projectPath, filename);
-                fs.copyFileSync('engine-patches/' + filename, patchLocation, fs.constants.COPYFILE_FICLONE);
+                fs.copyFileSync('engine-patches/' + filename, patchLocation);
                 indexContents = indexContents.replace(
                     '<script src="playcanvas-stable.min.js"></script>',
                     '<script src="playcanvas-stable.min.js"></script>\n    <script src="' + filename + '"></script>'
@@ -286,10 +286,10 @@ async function packageFiles (projectPath) {
 
                 // Copy files to a new dir
                 for (const filename of EXTERN_FILES) {
-                    fs.copyFileSync(path.resolve(projectPath, filename), path.resolve(packagePath, filename), fs.constants.COPYFILE_FICLONE);
+                    fs.copyFileSync(path.resolve(projectPath, filename), path.resolve(packagePath, filename));
                 }
 
-                fs.copyFileSync(indexLocation, path.resolve(packagePath, 'index.html'), fs.constants.COPYFILE_FICLONE);
+                fs.copyFileSync(indexLocation, path.resolve(packagePath, 'index.html'));
 
                 var zipOutputPath = path.resolve(__dirname, 'temp/out/' + config.playcanvas.name + '.zip');
                 await shared.zipProject(packagePath, zipOutputPath);
@@ -303,7 +303,7 @@ async function packageFiles (projectPath) {
                     });
                 }
 
-                fs.copyFileSync(indexLocation, indexOutputPath, fs.constants.COPYFILE_FICLONE);
+                fs.copyFileSync(indexLocation, indexOutputPath);
 
                 resolve(indexOutputPath);
             }


### PR DESCRIPTION
Until later versions where it expects an integer: https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_mode

Node 12 worked fine with the previous code but that was by luck as it didn't use a 3rd param. With Node 14+, it's used for a flag.