### PR TITLE
MRAID support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ temp/
 node_modules/
 .DS_Store
 config.json
+*.idea

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Adds an engine patch to remove any XHR requests and decodes the base64 URLs dire
 The option can be found in `config.json` under `one_page`. Set `patch_xhr_out` to true.
 
 #### Inline game scripts
-Adds an engine patch to decode base64 URLS for JS scripts when the engine adds them to the page document. This may be required for some platforms that block base64 encoded JS URLs. As this is a patch, there may be edge cases where some asset types may not work. If you find any any, please report them in the issues.
+Adds an engine patch to decode base64 URLS for JS scripts when the engine adds them to the page document. This may be required for some platforms that block base64 encoded JS URLs. As this is a patch, there may be edge cases where some asset types may not work. If you find any, please report them in the issues.
 
 The option can be found in `config.json` under `one_page`. Set `inline_game_scripts` to true.
 
@@ -151,6 +151,12 @@ The option can be found in `config.json` under `one_page`. Set `inline_game_scri
 Enabling this will keep the PlayCanvas engine code and game data as separate files. It will also zip up these files as the output file. This can be used for platforms that have a larger allowance for a zipped package to be used compared to a single HTML file.
 
 The option can be found in `config.json` under `one_page`. Set `extern_files` to true.
+
+#### MRAID interstitial support
+
+Adds basic support for MRAID API within the PlayCanvas engine and boilerplate code. 
+
+The option can be found in `config.json` under `one_page`. Set `mraid_support` to true.
 
 ### Usage
 1. `npm run one-page`

--- a/config.template.json
+++ b/config.template.json
@@ -28,6 +28,7 @@
     "one_page": {
         "patch_xhr_out": false,
         "inline_game_scripts": false,
-        "extern_files": false
+        "extern_files": false,
+        "mraid_support": false
     }
 }

--- a/one-page.js
+++ b/one-page.js
@@ -45,6 +45,31 @@ function inlineAssets(projectPath) {
                     console.log("↪️ Adding inline game script engine patch");
                     addPatchFile('one-page-inline-game-scripts.js');
                 }
+
+                // MRAID support needs to include the mraid.js file and also force the app to use filltype NONE
+                // so that it fits in the canvas that is sized by the MRAID implementation on the app. This requires
+                // patching the CSS too to ensure it is placed correctly in the Window
+                if (config.one_page.mraid_support) {
+                    console.log("↪️ Adding mraid.js as a library");
+                    indexContents = indexContents.replace(
+                        '<script src="playcanvas-stable.min.js"></script>',
+                        '<script src="mraid.js"></script>\n    <script src="playcanvas-stable.min.js"></script>'
+                    );
+
+                    console.log("↪️ Force fill type to be NONE in config.js");
+                    var configLocation = path.resolve(projectPath, "config.json");
+                    var configContents = fs.readFileSync(configLocation, 'utf-8');
+                    var configJson = JSON.parse(configContents);
+                    //configJson.application_properties.fillMode = "NONE";
+                    fs.writeFileSync(configLocation, JSON.stringify(configJson));
+
+                    console.log("↪️ Patch CSS to fill the canvas to the body");
+                    var cssLocation = path.resolve(projectPath, "styles.css");
+                    var cssContents = fs.readFileSync(cssLocation, 'utf-8');
+                    var cssRegex = /#application-canvas\.fill-mode-NONE[\s\S]*}/;
+                    cssContents = cssContents.replace(cssRegex, '#application-canvas.fill-mode-NONE { margin: 0; width: 100%; height: 100%; }');
+                    fs.writeFileSync(cssLocation, cssContents);
+                }
             })();
 
             // 1. Remove manifest.json and the reference in the index.html
@@ -62,7 +87,21 @@ function inlineAssets(projectPath) {
                 var contents = fs.readFileSync(location, 'utf-8');
 
                 var regex = /if \(PRELOAD_MODULES.length > 0\).*configure\(\);\n    }/s;
-                contents = contents.replace(regex, 'configure();');
+
+                if (config.one_page.mraid_support) {
+                    // if (window.mraid) {
+                    //     if (mraid.getState() !== 'ready') {
+                    //         mraid.addEventListener('ready', configure);
+                    //     } else {
+                    //         configure();
+                    //     }
+                    // } else {
+                    //     configure();
+                    // }
+                    contents = contents.replace(regex, 'window.mraid&&"ready"!==mraid.getState()?mraid.addEventListener("ready",configure):configure();');
+                } else {
+                    contents = contents.replace(regex, 'configure();');
+                }
                 fs.writeFileSync(location, contents);
             })();
 
@@ -94,7 +133,6 @@ function inlineAssets(projectPath) {
 
                 var configJson = JSON.parse(contents);
                 var assets = configJson.assets;
-
 
                 for (const [key, asset] of Object.entries(assets)) {
                     if (!Object.prototype.hasOwnProperty.call(assets, key)) {
@@ -256,6 +294,10 @@ function inlineAssets(projectPath) {
                     }
 
                     var filepath = path.resolve(projectPath, url);
+                    if (!fs.existsSync(filepath)) {
+                        continue;
+                    }
+
                     var fileContent = fs.readFileSync(filepath, 'utf-8');
 
                     // If it is already minified then don't try to minify it again

--- a/shared.js
+++ b/shared.js
@@ -20,6 +20,7 @@ function readConfig() {
     config.one_page.patch_xhr_out = config.one_page.patch_xhr_out || false;
     config.one_page.inline_game_scripts = config.one_page.inline_game_scripts || false;
     config.one_page.extern_files = config.one_page.extern_files || false;
+    config.one_page.mraid_support = config.one_page.mraid_support || false;
 
     return config;
 }


### PR DESCRIPTION
Adds the basic hooks for MRAID and forces the app to fit the canvas rather than the window as MRAID ads aren't always fullscreen.