### PR TITLE
Adding a test script to build all the common outputs for 'one-page' builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,8 @@ $ npm run one-page
     ✔️ Finishing up
     Success someProject.html
 ```
+
+#### Testing
+Please use the following command to create the most common outputs for the one-page job with public projects owned by the PlayCanvas team.
+
+1. `npm run test-one-page`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "csp": "node csp-patch.js",
     "archive": "node archive-project.js",
     "archive-all": "node archive-project-all.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test-one-page": "node tests/test-one-page.js",
     "one-page": "node one-page.js",
     "no-minify": "node no-minify.js"
   },

--- a/tests/configs-one-page/config.json.cubejump-mraid-interstitial.json
+++ b/tests/configs-one-page/config.json.cubejump-mraid-interstitial.json
@@ -1,0 +1,28 @@
+{
+    "playcanvas": {
+        "project_id": 775981,
+        "name": "Cube Jump MRAID Interstitial",
+        "scenes" : [1113087],
+        "branch_name": "master",
+        "branch_id": "94c72be8-ae43-4142-9d2a-6ea31039be11",
+        "description": "",
+        "preload_bundle": false,
+        "version": "",
+        "release_notes": "",
+        "scripts_concatenate": true,
+        "scripts_sourcemaps": false,
+        "optimize_scene_format": false
+    },
+    "csp": {
+        "style-src": [
+        ],
+        "connect-src": [
+        ]
+    },
+    "one_page": {
+        "patch_xhr_out": false,
+        "inline_game_scripts": true,
+        "extern_files": false,
+        "mraid_support": true
+    }
+}

--- a/tests/configs-one-page/config.json.cubejump-playable-fb.json
+++ b/tests/configs-one-page/config.json.cubejump-playable-fb.json
@@ -4,7 +4,7 @@
         "name": "Cube Jumper Playable FB",
         "scenes" : [380870],
         "branch_name": "master",
-        "branch_id": "4c4a2f8a-a927-47aa-bf6e-43b6528ded75",
+        "branch_id": "3c2266b4-4ec7-4616-959e-cf41833e99cf",
         "description": "",
         "preload_bundle": false,
         "version": "",

--- a/tests/configs-one-page/config.json.cubejump-playable-fb.json
+++ b/tests/configs-one-page/config.json.cubejump-playable-fb.json
@@ -1,0 +1,28 @@
+{
+    "playcanvas": {
+        "project_id": 354998,
+        "name": "Cube Jumper Playable FB",
+        "scenes" : [380870],
+        "branch_name": "master",
+        "branch_id": "4c4a2f8a-a927-47aa-bf6e-43b6528ded75",
+        "description": "",
+        "preload_bundle": false,
+        "version": "",
+        "release_notes": "",
+        "scripts_concatenate": true,
+        "scripts_sourcemaps": false,
+        "optimize_scene_format": false
+    },
+    "csp": {
+        "style-src": [
+        ],
+        "connect-src": [
+        ]
+    },
+    "one_page": {
+        "patch_xhr_out": true,
+        "inline_game_scripts": true,
+        "extern_files": false,
+        "mraid_support": true
+    }
+}

--- a/tests/configs-one-page/config.json.fileadaudit-mraid-interstitial.json
+++ b/tests/configs-one-page/config.json.fileadaudit-mraid-interstitial.json
@@ -1,0 +1,28 @@
+{
+    "playcanvas": {
+        "project_id": 749556,
+        "name": "File Ad Audit MRAID Interstitial",
+        "scenes" : [1059411],
+        "branch_name": "master",
+        "branch_id": "26ea4215-c688-46a2-8b62-f61beca75cd9",
+        "description": "",
+        "preload_bundle": false,
+        "version": "",
+        "release_notes": "",
+        "scripts_concatenate": true,
+        "scripts_sourcemaps": false,
+        "optimize_scene_format": false
+    },
+    "csp": {
+        "style-src": [
+        ],
+        "connect-src": [
+        ]
+    },
+    "one_page": {
+        "patch_xhr_out": false,
+        "inline_game_scripts": true,
+        "extern_files": false,
+        "mraid_support": true
+    }
+}

--- a/tests/configs-one-page/config.json.flappy-mraid-interstitial.json
+++ b/tests/configs-one-page/config.json.flappy-mraid-interstitial.json
@@ -1,0 +1,28 @@
+{
+    "playcanvas": {
+        "project_id": 783639,
+        "name": "Flappy Bird MRAID Interstitial",
+        "scenes" : [1128241],
+        "branch_name": "master",
+        "branch_id": "d43af44b-0f60-40f2-a8cf-abaf544d1e11",
+        "description": "",
+        "preload_bundle": false,
+        "version": "",
+        "release_notes": "",
+        "scripts_concatenate": true,
+        "scripts_sourcemaps": false,
+        "optimize_scene_format": false
+    },
+    "csp": {
+        "style-src": [
+        ],
+        "connect-src": [
+        ]
+    },
+    "one_page": {
+        "patch_xhr_out": false,
+        "inline_game_scripts": true,
+        "extern_files": false,
+        "mraid_support": true
+    }
+}

--- a/tests/configs-one-page/config.json.flappy-playable-fb.json
+++ b/tests/configs-one-page/config.json.flappy-playable-fb.json
@@ -1,0 +1,28 @@
+{
+    "playcanvas": {
+        "project_id": 785157,
+        "name": "Flappy Bird Playable FB",
+        "scenes" : [1131060],
+        "branch_name": "master",
+        "branch_id": "31ff2bba-9f97-4b4d-933b-e908e06c6429",
+        "description": "",
+        "preload_bundle": false,
+        "version": "",
+        "release_notes": "",
+        "scripts_concatenate": true,
+        "scripts_sourcemaps": false,
+        "optimize_scene_format": false
+    },
+    "csp": {
+        "style-src": [
+        ],
+        "connect-src": [
+        ]
+    },
+    "one_page": {
+        "patch_xhr_out": true,
+        "inline_game_scripts": true,
+        "extern_files": false,
+        "mraid_support": false
+    }
+}

--- a/tests/configs-one-page/config.json.flappy.json
+++ b/tests/configs-one-page/config.json.flappy.json
@@ -1,0 +1,28 @@
+{
+    "playcanvas": {
+        "project_id": 375389,
+        "name": "Flappy Bird",
+        "scenes" : [404993],
+        "branch_name": "master",
+        "branch_id": "605cd6ab-17b4-4dac-9960-ad439567c957",
+        "description": "",
+        "preload_bundle": false,
+        "version": "",
+        "release_notes": "",
+        "scripts_concatenate": true,
+        "scripts_sourcemaps": false,
+        "optimize_scene_format": false
+    },
+    "csp": {
+        "style-src": [
+        ],
+        "connect-src": [
+        ]
+    },
+    "one_page": {
+        "patch_xhr_out": false,
+        "inline_game_scripts": false,
+        "extern_files": false,
+        "mraid_support": false
+    }
+}

--- a/tests/configs-one-page/config.json.xwing-extern-files.json
+++ b/tests/configs-one-page/config.json.xwing-extern-files.json
@@ -1,0 +1,27 @@
+{
+    "playcanvas": {
+        "project_id": 395232,
+        "name": "X Wing Extern Files",
+        "scenes" : [427806],
+        "branch_name": "master",
+        "branch_id": "dfbe2442-0acf-49c2-8f5f-f32aa7aa6729",
+        "description": "",
+        "preload_bundle": false,
+        "version": "",
+        "release_notes": "",
+        "scripts_concatenate": true,
+        "scripts_sourcemaps": false,
+        "optimize_scene_format": false
+    },
+    "csp": {
+        "style-src": [
+        ],
+        "connect-src": [
+        ]
+    },
+    "one_page": {
+        "patch_xhr_out": false,
+        "inline_game_scripts": false,
+        "extern_files": true
+    }
+}

--- a/tests/test-one-page.js
+++ b/tests/test-one-page.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const childProcess = require('child_process');
+const { performance } = require('perf_hooks');
+
+const configsFolder = 'tests/configs-one-page';
+
+
+function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+// Go through all the public test configs to create the most common
+// outputs for the one-page job
+(async function() {
+    const files = fs.readdirSync(configsFolder);
+    const maxJobsPerMinute = 5;
+    const msInAMinute = 60 * 1000;
+
+    let msTakenSoFar = 0;
+
+    for (let i = 0; i < files.length; ++i) {
+        let timeStart = performance.now();
+        let file = files[i];
+        let fromPath = path.join(configsFolder, file);
+        let toPath = path.join('', 'config.json');
+
+        console.log('Using config \'' + file + '\'');
+
+        fs.copyFileSync(fromPath, toPath);
+        let output = childProcess.execSync('npm run one-page', {encoding: 'utf-8'});
+
+        console.log(output);
+
+        let timeEnd = performance.now();
+        msTakenSoFar += (timeEnd - timeStart);
+
+        // If we are not the last file, make sure to add some time between batches of REST API
+        // calls so that we don't hit the strict rate limit
+        if (i !== (files.length - 1)) {
+            if (i % maxJobsPerMinute === (maxJobsPerMinute - 1)) {
+                if (msTakenSoFar <= msInAMinute) {
+                    let msTillRateLimitEnds = msInAMinute - msTakenSoFar;
+                    console.log('Waiting till rate limit has passed (' + (msTillRateLimitEnds / 1000).toFixed(2) + 's)');
+                    await sleep(msInAMinute - msTakenSoFar);
+                }
+                msTakenSoFar = 0;
+            }
+        }
+    }
+})();


### PR DESCRIPTION
Adds a number of configs to public PlayCanvas projects to build against. There's one project that I'm not 100% sure to include into a public repo. If it could be replaced with another large project, that would be better.