### PR TITLE
Added feature to use a named folder for external files in one-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,17 @@ The option can be found in `config.json` under `one_page`. Set `inline_game_scri
 #### Extern files
 Enabling this will keep the PlayCanvas engine code and game data as separate files. It will also zip up these files as the output file. This can be used for platforms that have a larger allowance for a zipped package to be used compared to a single HTML file.
 
-The option can be found in `config.json` under `one_page`. Set `extern_files` to true.
+The option can be found in `config.json` under `one_page`. Set `extern_files.enabled` to true. The files can also be in a separate folder using `extern_files.folder_name` (defaults to the same directory).
+
+In some cases with ad networks, the external files will need to be hosted elsewhere such as a CDN. `extern_files.external_url_prefix` can be used to have the `index.html` reference the files to the CDN. E.g. 
+
+```
+"extern_files": {
+    "enabled": true,
+    "folder_name": "78fb9255-3033-4fe2-b9e1-355b149229a1",
+    "external_url_prefix": "https://some/random/cdn"
+}
+```
 
 #### MRAID interstitial support
 

--- a/config.template.json
+++ b/config.template.json
@@ -28,7 +28,11 @@
     "one_page": {
         "patch_xhr_out": false,
         "inline_game_scripts": false,
-        "extern_files": false,
+        "extern_files": {
+            "enable": false,
+            "folder_name": "",
+            "external_url_prefix": ""
+        },
         "mraid_support": false
     }
 }

--- a/shared.js
+++ b/shared.js
@@ -19,8 +19,24 @@ function readConfig() {
     config.one_page = config.one_page || {};
     config.one_page.patch_xhr_out = config.one_page.patch_xhr_out || false;
     config.one_page.inline_game_scripts = config.one_page.inline_game_scripts || false;
-    config.one_page.extern_files = config.one_page.extern_files || false;
     config.one_page.mraid_support = config.one_page.mraid_support || false;
+
+    // Mon 17 May 2021: Backwards compatibility when this used to be a boolean
+    // and convert to an object
+    var onePageExternFiles = config.one_page.extern_files;
+    if (onePageExternFiles) {
+        if (typeof onePageExternFiles === 'boolean') {
+            onePageExternFiles = {
+                enabled: onePageExternFiles
+            }
+        }
+    }
+
+    onePageExternFiles = onePageExternFiles || { enabled: false };
+    onePageExternFiles.folder_name = onePageExternFiles.folder_name || '';
+    onePageExternFiles.external_url_prefix = onePageExternFiles.external_url_prefix || '';
+
+    config.one_page.extern_files = onePageExternFiles;
 
     return config;
 }

--- a/tests/configs-one-page/config.json.xwing-extern-files.json
+++ b/tests/configs-one-page/config.json.xwing-extern-files.json
@@ -22,6 +22,8 @@
     "one_page": {
         "patch_xhr_out": false,
         "inline_game_scripts": false,
-        "extern_files": true
+        "extern_files": {
+            "enable": true
+        }
     }
 }


### PR DESCRIPTION
Fixes: #14 

Also have external URL support for ad networks that require external files to be hosted elsewhere such as a CDN