### PR TITLE
Move all script files to be external on extern_files config

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -29,7 +29,7 @@
         "patch_xhr_out": false,
         "inline_game_scripts": false,
         "extern_files": {
-            "enable": false,
+            "enabled": false,
             "folder_name": "",
             "external_url_prefix": ""
         },


### PR DESCRIPTION
Several ad networks have a restriction on the size of the index.html when extern files is used. This PR moves all scripts (eg if a user adds a library like cannon.js) to be external rather than embedding it into the index.html