### PR TITLE
Ironsource Ad MRAID support

### DIFF
--- a/engine-patches/one-page-mraid-resize-canvas.js
+++ b/engine-patches/one-page-mraid-resize-canvas.js
@@ -15,7 +15,7 @@
             windowHeight = mraidSize.height;
         }
 
-        if (this._fillMode === FILLMODE_KEEP_ASPECT) {
+        if (this._fillMode === pc.FILLMODE_KEEP_ASPECT) {
             var r = this.graphicsDevice.canvas.width / this.graphicsDevice.canvas.height;
             var winR = windowWidth / windowHeight;
 
@@ -26,7 +26,7 @@
                 height = windowHeight;
                 width = height * r;
             }
-        } else if (this._fillMode === FILLMODE_FILL_WINDOW) {
+        } else if (this._fillMode === pc.FILLMODE_FILL_WINDOW) {
             width = windowWidth;
             height = windowHeight;
         }

--- a/engine-patches/one-page-mraid-resize-canvas.js
+++ b/engine-patches/one-page-mraid-resize-canvas.js
@@ -1,0 +1,46 @@
+(function () {
+    pc.Application.prototype.resizeCanvas = function (width, height) {
+        if (!this._allowResize) return; // prevent resizing (e.g. if presenting in VR HMD)
+
+        // prevent resizing when in XR session
+        if (this.xr && this.xr.session)
+            return;
+
+        var windowWidth = window.innerWidth;
+        var windowHeight = window.innerHeight;
+
+        if (window.mraid) {
+            var mraidSize = mraid.getMaxSize();
+            windowWidth = mraidSize.width;
+            windowHeight = mraidSize.height;
+        }
+
+        if (this._fillMode === FILLMODE_KEEP_ASPECT) {
+            var r = this.graphicsDevice.canvas.width / this.graphicsDevice.canvas.height;
+            var winR = windowWidth / windowHeight;
+
+            if (r > winR) {
+                width = windowWidth;
+                height = width / r;
+            } else {
+                height = windowHeight;
+                width = height * r;
+            }
+        } else if (this._fillMode === FILLMODE_FILL_WINDOW) {
+            width = windowWidth;
+            height = windowHeight;
+        }
+        // OTHERWISE: FILLMODE_NONE use width and height that are provided
+
+        this.graphicsDevice.canvas.style.width = width + 'px';
+        this.graphicsDevice.canvas.style.height = height + 'px';
+
+        this.updateCanvasSize();
+
+        // return the final values calculated for width and height
+        return {
+            width: width,
+            height: height
+        };
+    }
+})();

--- a/one-page.js
+++ b/one-page.js
@@ -120,8 +120,9 @@ function inlineAssets(projectPath) {
                 // cssElement = document.createElement('style');
                 // cssElement.innerHTML =css;
                 // document.head.appendChild(cssElement);
-                //regex = /if \(document\.head\.querySelector\) {[\s\S]*?}/;
-                //contents = contents.replace(regex, 'cssElement=document.createElement("style"),cssElement.innerHTML=css,document.head.appendChild(cssElement);');
+
+                regex = /if \(document\.head\.querySelector\) {[\s\S]*?}/;
+                contents = contents.replace(regex, 'cssElement=document.createElement("style"),cssElement.innerHTML=css,document.head.appendChild(cssElement);');
 
                 fs.writeFileSync(location, contents);
             })();

--- a/one-page.js
+++ b/one-page.js
@@ -112,6 +112,15 @@ function inlineAssets(projectPath) {
                 } else {
                     contents = contents.replace(regex, 'configure();');
                 }
+
+                // // Adds the following code for better compatibility with ad networks on accessing the CSS styles
+                // // in configureCss()
+                // cssElement = document.createElement('style');
+                // cssElement.innerHTML =css;
+                // document.head.appendChild(cssElement);
+                //regex = /if \(document\.head\.querySelector\) {[\s\S]*?}/;
+                //contents = contents.replace(regex, 'cssElement=document.createElement("style"),cssElement.innerHTML=css,document.head.appendChild(cssElement);');
+
                 fs.writeFileSync(location, contents);
             })();
 

--- a/one-page.js
+++ b/one-page.js
@@ -78,6 +78,9 @@ function inlineAssets(projectPath) {
                     var cssRegex = /#application-canvas\.fill-mode-NONE[\s\S]*?}/;
                     cssContents = cssContents.replace(cssRegex, '#application-canvas.fill-mode-NONE { margin: 0; width: 100%; height: 100%; }');
                     fs.writeFileSync(cssLocation, cssContents);
+
+                    console.log("↪️ Adding mraid getMaxSize() call in pc.Application#resizeCanvas");
+                    addPatchFile('one-page-mraid-resize-canvas.js');
                 }
             })();
 


### PR DESCRIPTION
Changes made for MRAID support to work on Ironsource network: https://demos.ironsrc.com/test-tool/?adUnitLoader=mraid&mode=testing

Directly changing the CSS in `__start__.js` is not always possible and Ironsource requires the use of mraid.getMaxSize() so another patch to the engine was needed.