### PR TITLE
Added script to publish a build ready to be used for Cordova

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,30 @@ $ npm run one-page
 Please use the following command to create the most common outputs for the one-page job with public projects owned by the PlayCanvas team.
 
 1. `npm run test-one-page`
+
+
+## Cordova Publish
+
+This uses the [Download App REST API](https://developer.playcanvas.com/en/user-manual/api/app-download/) to download a build and also prepare it to be used with Cordova to create a native app.
+
+Currently, it does the following actions:
+* Adds `cordova.js` as a script header in `index.html`
+* Converts all audio assets to Base64 so they can be loaded on iOS
+
+### Usage
+1. `npm run cordova-publish`
+
+#### Example
+```
+$ npm run cordova-publish
+    ✔️ Requested build from Playcanvas
+    ↪️ Polling job  858473
+       job still running
+       will wait 1s and then retry
+    ↪️ Polling job  858473
+    ✔️ Job complete!
+    ✔ Downloading zip https://somefile.zip
+    ✔️ Unzipping  /somefile_Download.zip
+    ↪️ Base64 encode audio assets config.json
+    ✔️ Zipping it all back again
+```

--- a/cordova-publish.js
+++ b/cordova-publish.js
@@ -1,0 +1,88 @@
+const fs = require('fs')
+const path = require('path')
+const base64js = require('base64-js');
+const { minify } = require('terser');
+const btoa = require('btoa');
+const replaceString = require('replace-string');
+const lz4 = require('lz4');
+
+const shared = require('./shared');
+
+const config = shared.readConfig();
+
+var externFiles = [
+];
+
+function patch(projectPath) {
+    return new Promise((resolve, reject) => {
+        (async function() {
+            let indexLocation = path.resolve(projectPath, "index.html");
+            let indexContents = fs.readFileSync(indexLocation, 'utf-8');
+
+            indexContents = indexContents.replace(
+                '<script src="playcanvas-stable.min.js"></script>',
+                '<script src="playcanvas-stable.min.js"></script>\n    <script src="cordova.js"></script>'
+            );
+
+            // Open config.json and replace urls of audio assets with base64 strings of the files with
+            // the correct mime type. Also, delete the audio files to save on package size
+            await (async function() {
+                console.log("↪️ Base64 encode audio assets config.json");
+
+                let location = path.resolve(projectPath, "config.json");
+                let contents = fs.readFileSync(location, 'utf-8');
+
+                let configJson = JSON.parse(contents);
+                let assets = configJson.assets;
+
+                for (const [key, asset] of Object.entries(assets)) {
+                    if (!Object.prototype.hasOwnProperty.call(assets, key)) {
+                        continue;
+                    }
+
+                    // If it's not a file or an audio asset, we can ignore
+                    if (!asset.file || asset.type !== 'audio') {
+                        continue;
+                    }
+
+                    let url = unescape(asset.file.url);
+                    let urlSplit = url.split('.');
+                    let extension = urlSplit[urlSplit.length - 1];
+
+                    let filepath = path.resolve(projectPath, url);
+                    if (!fs.existsSync(filepath)) {
+                        console.log("   Cannot find file " + filepath + " If it's a loading screen script, please ignore");
+                        continue;
+                    }
+
+                    let fileContents = fs.readFileSync(filepath);
+                    let mimeprefix = "data:application/octet-stream";
+
+                    let ba = Uint8Array.from(fileContents);
+                    let b64 = base64js.fromByteArray(ba);
+
+                    // As we are using an escaped URL, we will search using the original URL
+                    asset.file.url = mimeprefix + ';base64,' + b64;
+
+                    // Remove the hash to prevent appending to the URL
+                    asset.file.hash = "";
+
+                    // Delete the audio file
+                    fs.unlinkSync(filepath);
+                };
+
+                fs.writeFileSync(location, JSON.stringify(configJson));
+            })();
+
+            fs.writeFileSync(indexLocation, indexContents);
+            resolve(projectPath);
+        })();
+    });
+}
+
+shared.downloadProject(config, "temp/downloads")
+    .then((zipLocation) => shared.unzipProject(zipLocation, 'contents') )
+    .then(patch)
+    .then((rootFolder) => shared.zipProject(rootFolder, 'temp/out/'+config.playcanvas.name+'_CordovaPublish.zip'))
+    .then(outputZip => console.log("Success", outputZip))
+    .catch(err => console.log("Error", err));

--- a/one-page.js
+++ b/one-page.js
@@ -324,7 +324,7 @@ function inlineAssets(projectPath) {
                 }
             })();
 
-            // 9. Compress the engine file with fflate
+            // 9. Compress the engine file with lz4
             (function() {
                 if (config.one_page.compress_engine) {
                     addLibraryFile('lz4.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,11 +48,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
-    "fflate": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
-      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg=="
-    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "archive-all": "node archive-project-all.js",
     "test-one-page": "node tests/test-one-page.js",
     "one-page": "node one-page.js",
-    "no-minify": "node no-minify.js"
+    "cordova-publish": "node cordova-publish.js"
   },
   "author": "support@playcanvas.com",
   "license": "MIT",


### PR DESCRIPTION
There's an issue with iOS where audio assets won't load. A workaround is to convert them to base64 instead which is what this script primarily does.

We can expand on this script as time goes on if there are common steps that need to taken with Cordova that we find.