### PR TITLE
CSP patching preload bundles is now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This uses the [Download App REST API](https://developer.playcanvas.com/en/user-m
 
 It will unzip the build, add the [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) rules to the `index.html` file and rezip the project.
 
-Please configure the CSP lists in `config.json` under `csp`.
+Please configure the CSP lists in `config.json` under `csp`. There is an option to also patch the preload bundles. To do so, set `patch_preload_bundles` to be true. 
 
 ### Usage
 1. `npm run csp`

--- a/csp-patch.js
+++ b/csp-patch.js
@@ -1,8 +1,5 @@
-const fetch = require('node-fetch')
-const dotenv = require('dotenv')
 const fs = require('fs')
 const path = require('path')
-const Zip = require('adm-zip');
 
 const shared = require('./shared');
 
@@ -12,20 +9,21 @@ const config = shared.readConfig();
 function updatePreloadBundles(rootFolder) {
     return new Promise((resolve) => {
         (async function() {
-            // Check if the preload bundles exist
-            const updateBundle = async function(bundleName) {
-                if (fs.existsSync(bundleName)) {
-                    console.log("↪️ Updating " + path.basename(bundleName));
+            if (config.csp.patch_preload_bundles) {
+                // Check if the preload bundles exist
+                const updateBundle = async function (bundleName) {
+                    if (fs.existsSync(bundleName)) {
+                        console.log("↪️ Updating " + path.basename(bundleName));
 
-                    const tempFolder = await shared.unzipProject(bundleName, 'bundle-temp');
-                    await addCspMetadata(tempFolder);
-                    await shared.zipProject(tempFolder, bundleName);
+                        const tempFolder = await shared.unzipProject(bundleName, 'bundle-temp');
+                        await addCspMetadata(tempFolder);
+                        await shared.zipProject(tempFolder, bundleName);
+                    }
                 }
+
+                await updateBundle(rootFolder + '/preload-android.zip');
+                await updateBundle(rootFolder + '/preload-ios.zip');
             }
-
-            await updateBundle(rootFolder + '/preload-android.zip');
-            await updateBundle(rootFolder + '/preload-ios.zip');
-
             resolve(rootFolder);
         })();
     });

--- a/shared.js
+++ b/shared.js
@@ -15,6 +15,7 @@ function readConfig() {
     config.csp = config.csp || {};
     config.csp['style-src'] = config.csp['style-src'] || [];
     config.csp['connect-src'] = config.csp['connect-src'] || [];
+    config.csp.patch_preload_bundles = config.csp.patch_preload_bundles || false;
 
     config.one_page = config.one_page || {};
     config.one_page.patch_xhr_out = config.one_page.patch_xhr_out || false;


### PR DESCRIPTION
Should fix #31 by making it optional. It is still unclear how the index.html in preload bundles work. No other reports have been made so making it optional by the user/developer.