### PR TITLE
[Playable Ads] - Updated no XHR engine patch for 1.63+. Uses Blobs to createImageBitmap

### DIFF
--- a/engine-patches/one-page-no-xhr-request.js
+++ b/engine-patches/one-page-no-xhr-request.js
@@ -21,6 +21,10 @@
                 bytes[i] = data.charCodeAt(i);
             }
             data = bytes.buffer;
+
+            if (url.startsWith('data:image/')) {
+                data = new Blob([data]); 
+            }
         }
 
         callback(null, data);


### PR DESCRIPTION
Fixes bug on https://forum.playcanvas.com/t/facebook-playable-ad-error/32993

Engine 1.63 made an internal engine change to use blobs to createImageBitmap. (PR https://github.com/playcanvas/engine/pull/5232)

This PR updates the engine patch to not use XHR as that's needed for Facebook Ads