### PR TITLE
[One Page/Playable Ad] Disabled supportsImageBitmap if no XHR is used

### DIFF
--- a/engine-patches/one-page-no-xhr-request.js
+++ b/engine-patches/one-page-no-xhr-request.js
@@ -3,8 +3,8 @@
     // We override the setting in configure before we load assets
     var oldAppConfigure = pc.Application.prototype.configure;
     pc.Application.prototype.configure = function (json, callback) {
-      this.graphicsDevice.supportsImageBitmap = false;
-      oldAppConfigure.call(this, json, callback);
+        this.graphicsDevice.supportsImageBitmap = false;
+        oldAppConfigure.call(this, json, callback);
     };
 
     pc.Http.prototype.get = function get(url, options, callback) {

--- a/engine-patches/one-page-no-xhr-request.js
+++ b/engine-patches/one-page-no-xhr-request.js
@@ -1,4 +1,12 @@
 (function () {
+    // Patch out supportsImageBitmap as that doesn't load some images when XHR is also patched out
+    // We override the setting in configure before we load assets
+    var oldAppConfigure = pc.Application.prototype.configure;
+    pc.Application.prototype.configure = function (json, callback) {
+      this.graphicsDevice.supportsImageBitmap = false;
+      oldAppConfigure.call(this, json, callback);
+    };
+
     pc.Http.prototype.get = function get(url, options, callback) {
         if (typeof options === "function") {
             callback = options;

--- a/one-page.js
+++ b/one-page.js
@@ -56,7 +56,7 @@ function inlineAssets(projectPath) {
 
                 // Patch the engine app configure function to take a JSON object instead of a URL
                 // so we don't need to Base64 the config.json and take another ~30% hit on file size
-                // This patch should be done after XHR patch because the XHR patch depends on the coonfigure patch
+                // This patch should be done after XHR patch because the XHR patch depends on the configure patch
                 // Patching is done last in, first out so it gets added to the top of the script order in the HTML
                 console.log("↪️ Adding app configure engine patch");
                 addPatchFile('one-page-app-configure-json.js');

--- a/one-page.js
+++ b/one-page.js
@@ -56,6 +56,8 @@ function inlineAssets(projectPath) {
 
                 // Patch the engine app configure function to take a JSON object instead of a URL
                 // so we don't need to Base64 the config.json and take another ~30% hit on file size
+                // This patch should be done after XHR patch because the XHR patch depends on the coonfigure patch
+                // Patching is done last in, first out so it gets added to the top of the script order in the HTML
                 console.log("↪️ Adding app configure engine patch");
                 addPatchFile('one-page-app-configure-json.js');
 


### PR DESCRIPTION
Fixes a bug where some textures aren't loading if no XHR is patched into the build (for FB playable ads) due to the following error:

```
TypeError: Failed to execute 'createImageBitmap' on 'Window': The provided value is not of type '(Blob or HTMLCanvasElement or HTMLImageElement or HTMLVideoElement or ImageBitmap or ImageData or OffscreenCanvas or SVGImageElement or VideoFrame)'.
```

And it looks like this
![SCR-20240215-mmix](https://github.com/playcanvas/playcanvas-rest-api-tools/assets/16639049/4f684627-a5fc-4baa-a440-3a0f57aeead3)

Instead of 
![SCR-20240215-mmfh](https://github.com/playcanvas/playcanvas-rest-api-tools/assets/16639049/26c10d32-ab19-43ec-9b5f-f2e8dadd8666)

This PR disables `supportsImageBitmap` when no XHR is used