### PR TITLE
adds alternative css regexp

### DIFF
--- a/one-page.js
+++ b/one-page.js
@@ -128,7 +128,7 @@ function inlineAssets(projectPath) {
                 // cssElement.innerHTML =css;
                 // document.head.appendChild(cssElement);
 
-                regex = /if \(document\.head\.querySelector\) {[\s\S]*?}/;
+                regex = /document\.head\.querySelector\('style'\)\.innerHTML \+= css;/;
                 contents = contents.replace(regex, 'cssElement=document.createElement("style"),cssElement.innerHTML=css,document.head.appendChild(cssElement);');
 
                 fs.writeFileSync(location, contents);


### PR DESCRIPTION
A change in `__start__.js` on monorepo introduced a template literal which broke the Regexp test in `one-page.js` This PR adds a fix to handle the new `__start__.js`

[Reported on Discord](https://discord.com/channels/408617316415307776/408617316415307778/1219579560522416199)

