### PR TITLE
[One Page/Playable Ad] Asset Size Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ $ npm run one-page
     Success someProject.html
 ```
 
+#### Testing
+Please use the following command to create the most common outputs for the one-page job with public projects owned by the PlayCanvas team.
+
+1. `npm run test-one-page`
+
 ### Asset Size Report
 To get a size report of the one-page job, use the following command:
 1. `npm run one-page --size-report`
@@ -233,12 +238,6 @@ Size Report
    Total size: 500848 bytes
    Total asset size in MB: 0.48 MB
 ```
-
-#### Testing
-Please use the following command to create the most common outputs for the one-page job with public projects owned by the PlayCanvas team.
-
-1. `npm run test-one-page`
-
 
 ## Cordova Publish
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,21 @@ $ npm run one-page
     Success someProject.html
 ```
 
+### Asset Size Report
+To get a size report of the one-page job, use the following command:
+1. `npm run one-page --size-report`
+#### Example
+```
+Size Report
+   Character.glb - 311472 bytes
+   Character.png - 165976 bytes
+   MaterialShader.js - 14980 bytes
+   Fire-Noise.jpg - 6696 bytes
+   Sound.mp3 - 1724 bytes
+   Total size: 500848 bytes
+   Total asset size in MB: 0.48 MB
+```
+
 #### Testing
 Please use the following command to create the most common outputs for the one-page job with public projects owned by the PlayCanvas team.
 

--- a/one-page.js
+++ b/one-page.js
@@ -163,6 +163,8 @@ function inlineAssets(projectPath) {
                 var configJson = JSON.parse(contents);
                 var assets = configJson.assets;
 
+                var sizeReport = [];
+
                 for (const [key, asset] of Object.entries(assets)) {
                     if (!Object.prototype.hasOwnProperty.call(assets, key)) {
                         continue;
@@ -256,12 +258,29 @@ function inlineAssets(projectPath) {
                         b64 = base64js.fromByteArray(ba);
                     }
 
+                    sizeReport.push({
+                        name: asset.name,
+                        size: b64.length
+                    });
+
                     // As we are using an escaped URL, we will search using the original URL
                     asset.file.url = mimeprefix + ';base64,' + b64;
 
                     // Remove the hash to prevent appending to the URL
                     asset.file.hash = "";
                 };
+
+                if (process.argv.includes('--size-report')) {
+                    sizeReport.sort((a, b) => b.size - a.size);
+                    console.log("↪️ Size Report");
+                    sizeReport.forEach((item) => {
+                        console.log("   " + item.name + " - " + item.size + " bytes");
+                    });
+
+                    const totalSize = sizeReport.reduce((acc, item) => acc + item.size, 0);
+                    console.log("   Total size: " + totalSize + " bytes");
+                    console.log("   Total asset size in MB: " + (totalSize / 1024 / 1024).toFixed(2) + " MB");
+                }
 
                 fs.writeFileSync(location, JSON.stringify(configJson));
             })();


### PR DESCRIPTION
Adds a convenient size report for all the assets when adding `--size-report` to the `one-page` command.
```
Size Report
   Character.glb - 311472 bytes
   Character.png - 165976 bytes
   MaterialShader.js - 14980 bytes
   Fire-Noise.jpg - 6696 bytes
   Sound.mp3 - 1724 bytes
   Total size: 500848 bytes
   Total asset size in MB: 0.48 MB
```